### PR TITLE
Update fable-remoting.md to accomodate features from safe server metapackage

### DIFF
--- a/docs/recipes/client-server/fable-remoting.md
+++ b/docs/recipes/client-server/fable-remoting.md
@@ -59,6 +59,13 @@ let myApi =
     |> Remoting.buildProxy<IMyApi>
 ```
 
+> Note: We have made your life easier by creating Metapackages which abstract some of this boilerplate. You can also create the client proxy like so:
+> ```fsharp
+> open SAFE
+>
+> let myApi = Api.makeProxy<IMyApi> ()
+> ```
+
 #### 7. Make calls to the Server
 Replace the following two lines in the `init` function in `Client.fs`:
 


### PR DESCRIPTION
Given we now have Metapackages which allow us to write even more succint full stack apps - we should also make reference to them wherever we can in the SAFE stack docs. `makeProxy` is a good example of such case